### PR TITLE
Update conda_env.yml - missing openblas dependency

### DIFF
--- a/conda_env.yml
+++ b/conda_env.yml
@@ -9,3 +9,4 @@ dependencies:
   - pandas
   - joblib
   - pyarrow
+  - openblas


### PR DESCRIPTION
I was getting errors related to openblas upon `import brian2` , fixed by adding it as a dependency